### PR TITLE
filter empty entries

### DIFF
--- a/attributes/express_multiple/controller.php
+++ b/attributes/express_multiple/controller.php
@@ -53,7 +53,7 @@ class Controller extends \Concrete\Attribute\Express\Controller
             }
         }
 
-        return $this->createAttributeValue($entries);
+        return $this->createAttributeValue(array_filter($entries));
     }
 
     public function getSearchIndexValue()


### PR DESCRIPTION
When using this attribute in a composer form concrete5 tries to autosave periodically. If there is not a selection for this attribute, the save will fail with a 500 error due to trying to save a null entry. By filtering the array before saving, null and empty selections are not passed along to the createAttributeValue() method

closes #2 